### PR TITLE
Add safe singleton initialization for WireguardBackend

### DIFF
--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardBackend.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardBackend.kt
@@ -53,6 +53,21 @@ class WireguardBackend private constructor(
                 Log.d("WireguardBackend", "Backend singleton initialized")
             }
         }
+
+        fun getOrCreateInstance(context: Context): WireguardBackend {
+            if (!::instance.isInitialized) {
+                synchronized(this) {
+                    if (!::instance.isInitialized) {
+                        instance = WireguardBackend(
+                            context.applicationContext,
+                            CoroutineScope(Job() + Dispatchers.Main.immediate)
+                        )
+                        Log.d("WireguardBackend", "Backend singleton auto-initialized from service")
+                    }
+                }
+            }
+            return instance
+        }
     }
 
     fun serviceCreated(service: WireguardWrapperService) {

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -17,12 +17,13 @@ class WireguardWrapperService : GoBackend.VpnService() {
         super.onCreate()
         notificationHelper = NotificationHelper(this)
         NotificationHelper.initNotificationChannel(this)
-        WireguardBackend.instance.serviceCreated(this)
+        val backend = WireguardBackend.getOrCreateInstance(this)
+        backend.serviceCreated(this)
         Log.d(serviceTag, "Service created")
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val backend = WireguardBackend.instance
+        val backend = WireguardBackend.getOrCreateInstance(this)
 
         // Show foreground notification immediately
         startForeground(
@@ -70,7 +71,7 @@ class WireguardWrapperService : GoBackend.VpnService() {
 
     override fun onDestroy() {
         updateJob?.cancel()
-        WireguardBackend.instance.serviceDestroyed()
+        WireguardBackend.getOrCreateInstance(this).serviceDestroyed()
         super.onDestroy()
         Log.d(serviceTag, "Service destroyed")
     }


### PR DESCRIPTION
This pull request updates the initialization and usage of the `WireguardBackend` singleton to ensure it is safely and lazily instantiated when accessed from the `WireguardWrapperService`. The changes improve thread safety and prevent potential issues with uninitialized singletons.

**WireguardBackend singleton initialization improvements:**

* Added a new method `getOrCreateInstance(context: Context)` to `WireguardBackend` that lazily and thread-safely initializes the singleton if it hasn't been created yet, ensuring the application context is used.

**WireguardWrapperService usage updates:**

* Replaced direct access to `WireguardBackend.instance` with `WireguardBackend.getOrCreateInstance(this)` in the `onCreate`, `onStartCommand`, and `onDestroy` methods to guarantee the backend is always properly initialized before use. [[1]](diffhunk://#diff-ca92fc12b41c361a10effbbb384e23e8eb348cc79e8d021796e4eaa9285f7d8bL20-R26) [[2]](diffhunk://#diff-ca92fc12b41c361a10effbbb384e23e8eb348cc79e8d021796e4eaa9285f7d8bL73-R74)Introduced getOrCreateInstance to ensure WireguardBackend is properly initialized before use. Updated WireguardWrapperService to use the new method, preventing potential uninitialized access to the singleton.