### PR TITLE
Update Mockito dependency to 5.6.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mockito: 5.5.1
+  mockito: 5.6.3
   plugin_platform_interface: ^2.1.8
 
 dev_dependencies:


### PR DESCRIPTION
Bump mockito from version 5.5.1 to 5.6.3 to include the latest features and bug fixes.