### PR TITLE
fix: upgrade WireGuard tunnel v1.0.20260102 (16KB compliant)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '2.2.10'
-    ext.wireguard_tunnel_version = '1.0.20230706'
+    ext.wireguard_tunnel_version = '1.0.20260102'
     repositories {
         google()
         mavenCentral()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wireguard_dart
 description: Wireguard Dart SDK
-version: 0.4.5
+version: 0.4.6
 homepage: https://github.com/mysteriumnetwork/wireguard_dart
 repository: https://github.com/mysteriumnetwork/wireguard_dart
 


### PR DESCRIPTION
## WireGuard Tunnel Library Upgrade ✅

**What:**
- up ext.wireguard_tunnel_version → '1.0.20260102' 
- add 16KB page size support (Google Play compliance)

**Why:**
Fixes ELF alignment errors for libwg*.so on Android 15+