### PR TITLE
Throttle notifications and add permission checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ It includes [Wireguard implementation for the corresponding OS](https://www.wire
 
 To use this plugin, add `wireguard_dart` as a [dependency in your pubspec.yaml file](https://flutter.dev/platform-plugins/).
 
+### Android
+
+On Android 13+ (API 33+), VPN startup requires notification permission.
+This package declares `android.permission.POST_NOTIFICATIONS` in its library manifest, but your app still needs to request this permission at runtime before starting a tunnel.
+
 ## Development
 
 - Create a PR with proposed changes:

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ To use this plugin, add `wireguard_dart` as a [dependency in your pubspec.yaml f
 
 ### Android
 
-On Android 13+ (API 33+), VPN startup requires notification permission.
-This package declares `android.permission.POST_NOTIFICATIONS` in its library manifest, but your app still needs to request this permission at runtime before starting a tunnel.
+On Android 13+ (API 33+), this package declares `android.permission.POST_NOTIFICATIONS` in its library manifest.
+`connect()` does not hard-fail when this permission is not granted, but requesting notification permission is still recommended for proper foreground notification visibility.
 
 ## Development
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,14 +3,14 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '2.2.10'
-    ext.wireguard_tunnel_version = '1.0.20230706'
+    ext.wireguard_tunnel_version = '1.0.20260102'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
@@ -87,8 +87,8 @@ class NotificationHelper(private val context: Context) {
         status: ConnectionStatus,
         stats: TunnelStatistics? = null,
         notificationTitle: String,
-    ) {
-        notifySafely(
+    ): Boolean {
+        return notifySafely(
             NOTIFICATION_ID,
             buildTunnelNotification(status, stats, notificationTitle)
         )
@@ -113,16 +113,24 @@ class NotificationHelper(private val context: Context) {
         }
     }
 
-    private fun notifySafely(notificationId: Int, notification: Notification) {
+    private fun notifySafely(notificationId: Int, notification: Notification): Boolean {
         if (!hasPostNotificationsPermission()) {
-            return
+            Log.w(logTag, "Skipping notify: POST_NOTIFICATIONS permission not granted")
+            return false
         }
 
         val manager = context.getSystemService(NotificationManager::class.java)
+        if (manager == null) {
+            Log.w(logTag, "Unable to update notification: NotificationManager unavailable")
+            return false
+        }
+
         try {
-            manager?.notify(notificationId, notification)
+            manager.notify(notificationId, notification)
+            return true
         } catch (e: SecurityException) {
             Log.w(logTag, "Unable to update notification due to security restriction", e)
+            return false
         }
     }
 

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
@@ -99,11 +99,6 @@ class NotificationHelper(private val context: Context) {
         notificationId: Int,
         notification: Notification,
     ): Boolean {
-        if (!hasPostNotificationsPermission()) {
-            Log.w(logTag, "Skipping startForeground: POST_NOTIFICATIONS permission not granted")
-            return false
-        }
-
         return try {
             service.startForeground(notificationId, notification)
             true

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
@@ -1,10 +1,10 @@
 package network.mysterium.wireguard_dart
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.Service
 import android.content.pm.PackageManager
 import android.content.Context
 import android.content.Intent
@@ -88,18 +88,50 @@ class NotificationHelper(private val context: Context) {
         stats: TunnelStatistics? = null,
         notificationTitle: String,
     ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-            context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
-        ) {
+        notifySafely(
+            NOTIFICATION_ID,
+            buildTunnelNotification(status, stats, notificationTitle)
+        )
+    }
+
+    fun startForegroundSafely(
+        service: Service,
+        notificationId: Int,
+        notification: Notification,
+    ): Boolean {
+        if (!hasPostNotificationsPermission()) {
+            Log.w(logTag, "Skipping startForeground: POST_NOTIFICATIONS permission not granted")
+            return false
+        }
+
+        return try {
+            service.startForeground(notificationId, notification)
+            true
+        } catch (e: SecurityException) {
+            Log.w(logTag, "Unable to start foreground notification due to security restriction", e)
+            false
+        }
+    }
+
+    private fun notifySafely(notificationId: Int, notification: Notification) {
+        if (!hasPostNotificationsPermission()) {
             return
         }
 
         val manager = context.getSystemService(NotificationManager::class.java)
         try {
-            manager?.notify(NOTIFICATION_ID, buildTunnelNotification(status, stats, notificationTitle))
+            manager?.notify(notificationId, notification)
         } catch (e: SecurityException) {
             Log.w(logTag, "Unable to update notification due to security restriction", e)
         }
+    }
+
+    private fun hasPostNotificationsPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+
+        return context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun formatBytes(bytes: Long): String {

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
@@ -1,16 +1,21 @@
 package network.mysterium.wireguard_dart
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.content.pm.PackageManager
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import java.util.Locale
 
 class NotificationHelper(private val context: Context) {
+
+    private val logTag = "NotificationHelper"
 
     companion object {
         const val CHANNEL_ID = "network_wireguard_channel"
@@ -50,21 +55,32 @@ class NotificationHelper(private val context: Context) {
             "$baseText • ↑ $upload • ↓ $download"
         } else baseText
 
-        val pending = android.app.PendingIntent.getActivity(
-            context,
-            0,
-            Intent(context, getLaunchActivityClass(context)),
-            android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
-        )
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            ?.apply {
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
 
-        return NotificationCompat.Builder(context, CHANNEL_ID)
+        val pending = launchIntent?.let {
+            android.app.PendingIntent.getActivity(
+                context,
+                0,
+                it,
+                android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle(notificationTitle)
             .setContentText(text)
             .setSmallIcon(R.drawable.baseline_vpn_key_24)
-            .setContentIntent(pending)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
-            .build()
+
+        if (pending != null) {
+            builder.setContentIntent(pending)
+        }
+
+        return builder.build()
     }
 
     fun updateStatusNotification(
@@ -72,8 +88,18 @@ class NotificationHelper(private val context: Context) {
         stats: TunnelStatistics? = null,
         notificationTitle: String,
     ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+
         val manager = context.getSystemService(NotificationManager::class.java)
-        manager?.notify(NOTIFICATION_ID, buildTunnelNotification(status, stats, notificationTitle))
+        try {
+            manager?.notify(NOTIFICATION_ID, buildTunnelNotification(status, stats, notificationTitle))
+        } catch (e: SecurityException) {
+            Log.w(logTag, "Unable to update notification due to security restriction", e)
+        }
     }
 
     private fun formatBytes(bytes: Long): String {
@@ -85,21 +111,6 @@ class NotificationHelper(private val context: Context) {
             bytes >= mb -> String.format(Locale.US, "%.2f MB", bytes.toDouble() / mb)
             bytes >= kb -> String.format(Locale.US, "%.2f KB", bytes.toDouble() / kb)
             else -> "$bytes B"
-        }
-    }
-
-
-    @SuppressLint("DiscouragedPrivateApi")
-    private fun getLaunchActivityClass(context: Context): Class<*> {
-        val pm = context.packageManager
-        val intent = pm.getLaunchIntentForPackage(context.packageName)
-        val className = intent?.component?.className
-        return try {
-            val classNameNonNull =
-                className ?: throw IllegalStateException("Launch activity className is null")
-            Class.forName(classNameNonNull)
-        } catch (_: Exception) {
-            android.app.Activity::class.java
         }
     }
 }

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardBackend.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardBackend.kt
@@ -1,7 +1,9 @@
 package network.mysterium.wireguard_dart
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import com.wireguard.android.backend.GoBackend
@@ -88,6 +90,12 @@ class WireguardBackend private constructor(
         Log.d(serviceTag, "connectFromService: Initializing tunnel '$tunnelName'")
         withContext(wireGuardDispatcher) {
             try {
+                if (!startServiceIfNeeded(context)) {
+                    throw IllegalStateException(
+                        "POST_NOTIFICATIONS permission is required to start VPN foreground service"
+                    )
+                }
+
                 val cfg = Config.parse(ByteArrayInputStream(cfgString.toByteArray()))
                 currentConfig = cfg
 
@@ -98,9 +106,6 @@ class WireguardBackend private constructor(
                             Tunnel.State.UP -> ConnectionStatus.connected
                             Tunnel.State.DOWN -> ConnectionStatus.disconnected
                             else -> ConnectionStatus.unknown
-                        }
-                        if (newStatus == ConnectionStatus.connected) {
-                            startServiceIfNeeded(context)
                         }
                         Log.d(
                             serviceTag,
@@ -168,7 +173,15 @@ class WireguardBackend private constructor(
         }
     }
 
-    fun startServiceIfNeeded(context: Context) {
+    fun startServiceIfNeeded(context: Context): Boolean {
+        if (!canPostNotifications(context)) {
+            Log.w(
+                serviceTag,
+                "Not starting WireguardWrapperService: POST_NOTIFICATIONS permission not granted"
+            )
+            return false
+        }
+
         val intent = Intent(context, WireguardWrapperService::class.java)
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -177,9 +190,19 @@ class WireguardBackend private constructor(
                 context.startService(intent)
             }
             Log.d(serviceTag, "WireguardWrapperService started")
+            return true
         } catch (e: Exception) {
             Log.e(serviceTag, "Failed to start WireguardWrapperService", e)
+            return false
         }
+    }
+
+    private fun canPostNotifications(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+
+        return context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
     }
 
     suspend fun closeVpnTunnel(withStateChange: Boolean, context: Context) {

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardBackend.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardBackend.kt
@@ -1,9 +1,7 @@
 package network.mysterium.wireguard_dart
 
-import android.Manifest
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import com.wireguard.android.backend.GoBackend
@@ -91,9 +89,7 @@ class WireguardBackend private constructor(
         withContext(wireGuardDispatcher) {
             try {
                 if (!startServiceIfNeeded(context)) {
-                    throw IllegalStateException(
-                        "POST_NOTIFICATIONS permission is required to start VPN foreground service"
-                    )
+                    throw Exception("Failed to start WireguardWrapperService")
                 }
 
                 val cfg = Config.parse(ByteArrayInputStream(cfgString.toByteArray()))
@@ -127,7 +123,12 @@ class WireguardBackend private constructor(
                 Log.e(serviceTag, "connectFromService failed: $detailedMessage")
                 updateStatus(ConnectionStatus.disconnected)
                 _latestStats = null
-                throw WireguardConnectionException(tunnelName, e, detailedMessage)
+                throw WireguardConnectionException(
+                    tunnelName,
+                    e,
+                    detailedMessage,
+                    WireguardErrorCode.CONNECTION_FAILED
+                )
             }
         }
     }
@@ -174,14 +175,6 @@ class WireguardBackend private constructor(
     }
 
     fun startServiceIfNeeded(context: Context): Boolean {
-        if (!canPostNotifications(context)) {
-            Log.w(
-                serviceTag,
-                "Not starting WireguardWrapperService: POST_NOTIFICATIONS permission not granted"
-            )
-            return false
-        }
-
         val intent = Intent(context, WireguardWrapperService::class.java)
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -195,14 +188,6 @@ class WireguardBackend private constructor(
             Log.e(serviceTag, "Failed to start WireguardWrapperService", e)
             return false
         }
-    }
-
-    private fun canPostNotifications(context: Context): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            return true
-        }
-
-        return context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
     }
 
     suspend fun closeVpnTunnel(withStateChange: Boolean, context: Context) {

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardConnectionException.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardConnectionException.kt
@@ -1,7 +1,12 @@
 package network.mysterium.wireguard_dart
 
+object WireguardErrorCode {
+    const val CONNECTION_FAILED = "ERR_WIREGUARD_CONNECTION"
+}
+
 class WireguardConnectionException(
     val tunnelName: String,
     val originalException: Exception,
-    val details: String
+    val details: String,
+    val errorCode: String = WireguardErrorCode.CONNECTION_FAILED
 ) : Exception("Wireguard connection failed for tunnel '$tunnelName': ${originalException.message}")

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardDartPlugin.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardDartPlugin.kt
@@ -129,12 +129,13 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
         // Existing VPN permission handling
         if (requestCode == PERMISSIONS_REQUEST_CODE) {
             havePermission = resultCode == Activity.RESULT_OK
-            if (havePermission) permissionsResultCallback?.success(null)
-            else permissionsResultCallback?.error(
-                "err_setup_tunnel",
-                "Permissions are not given",
-                null
-            )
+            permissionsResultCallback?.let { callback ->
+                if (havePermission) {
+                    flutterSuccess(callback, null)
+                } else {
+                    flutterError(callback, "err_setup_tunnel", "Permissions are not given")
+                }
+            }
             return true
         }
 
@@ -150,6 +151,10 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
         scope.launch(Dispatchers.Main) { result.error(error, null, null) }
     }
 
+    private fun flutterError(result: MethodChannel.Result, errorCode: String, errorMessage: String?) {
+        scope.launch(Dispatchers.Main) { result.error(errorCode, errorMessage, null) }
+    }
+
     private fun flutterNotImplemented(result: MethodChannel.Result) {
         scope.launch(Dispatchers.Main) { result.notImplemented() }
     }
@@ -157,7 +162,7 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
     // === Dart exposed methods ===
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
-            "nativeInit" -> result.success("")
+            "nativeInit" -> flutterSuccess(result, "")
             "generateKeyPair" -> generateKeyPair(result)
             "setupTunnel" -> setupTunnel(
                 call.argument<String>("tunnelName").toString(),
@@ -181,7 +186,8 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
 
     private fun generateKeyPair(result: MethodChannel.Result) {
         val keyPair = KeyPair()
-        result.success(
+        flutterSuccess(
+            result,
             hashMapOf(
                 "privateKey" to keyPair.privateKey.toBase64(),
                 "publicKey" to keyPair.publicKey.toBase64()
@@ -213,7 +219,7 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
         val intent = GoBackend.VpnService.prepare(activity)
         havePermission = intent == null
         if (havePermission) initTunnel(tunnelName)
-        result.success(havePermission)
+        flutterSuccess(result, havePermission)
     }
 
     private fun connect(cfg: String, result: MethodChannel.Result) {
@@ -236,17 +242,7 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
                 flutterSuccess(result, "")
             } catch (e: WireguardConnectionException) {
                 Log.e(TAG, "connectFromService failed: ${e.details}")
-                if (e.originalException is IllegalStateException &&
-                    e.originalException.message?.contains("POST_NOTIFICATIONS") == true
-                ) {
-                    result.error(
-                        "ERR_NOTIFICATION_PERMISSION",
-                        "Notification permission is required to start VPN foreground service. Request POST_NOTIFICATIONS and retry.",
-                        null
-                    )
-                } else {
-                    flutterError(result, e.details)
-                }
+                flutterError(result, e.errorCode, e.details)
             } catch (e: Exception) {
                 Log.e(TAG, "connectFromService failed", e)
                 flutterError(
@@ -305,13 +301,13 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
     }
 
     private fun status(result: MethodChannel.Result) {
-        result.success(WireguardBackend.instance.statusFlow.value.name)
+        flutterSuccess(result, WireguardBackend.instance.statusFlow.value.name)
     }
 
     private fun requestNotificationPermission(result: MethodChannel.Result) {
         val callback = object : NotificationPermissionCallback {
             override fun onResult(permissionStatus: NotificationPermission) {
-                result.success(permissionStatus.name)
+                flutterSuccess(result, permissionStatus.name)
             }
 
             override fun onError(exception: Exception) {
@@ -325,7 +321,7 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
         try {
             val callback = object : NotificationPermissionCallback {
                 override fun onResult(permissionStatus: NotificationPermission) {
-                    result.success(permissionStatus.name)
+                    flutterSuccess(result, permissionStatus.name)
                 }
 
                 override fun onError(exception: Exception) {
@@ -334,14 +330,14 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
             }
             notificationPermissionManager.openAppNotificationSettings(checkActivity(), callback)
         } catch (e: Exception) {
-            result.error("ERR_OPEN_NOTIFICATION_SETTINGS", e.message, null)
+            flutterError(result, "ERR_OPEN_NOTIFICATION_SETTINGS", e.message)
         }
     }
 
 
     private fun checkNotificationPermission(result: MethodChannel.Result) {
         val status = notificationPermissionManager.checkPermission(checkActivity())
-        result.success(status.name)
+        flutterSuccess(result, status.name)
     }
 
     private fun checkActivity(): Activity {

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardDartPlugin.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardDartPlugin.kt
@@ -236,7 +236,17 @@ class WireguardDartPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Acti
                 flutterSuccess(result, "")
             } catch (e: WireguardConnectionException) {
                 Log.e(TAG, "connectFromService failed: ${e.details}")
-                flutterError(result, e.details)
+                if (e.originalException is IllegalStateException &&
+                    e.originalException.message?.contains("POST_NOTIFICATIONS") == true
+                ) {
+                    result.error(
+                        "ERR_NOTIFICATION_PERMISSION",
+                        "Notification permission is required to start VPN foreground service. Request POST_NOTIFICATIONS and retry.",
+                        null
+                    )
+                } else {
+                    flutterError(result, e.details)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "connectFromService failed", e)
                 flutterError(

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -2,11 +2,16 @@ package network.mysterium.wireguard_dart
 
 import android.content.Intent
 import android.os.IBinder
+import android.os.SystemClock
 import android.util.Log
 import com.wireguard.android.backend.GoBackend
 import kotlinx.coroutines.*
 
 class WireguardWrapperService : GoBackend.VpnService() {
+
+    companion object {
+        private const val NOTIFICATION_UPDATE_MIN_INTERVAL_MS = 2_000L
+    }
 
     private val serviceTag = "WireguardWrapperService"
     private val scope = CoroutineScope(Job() + Dispatchers.Main)
@@ -38,11 +43,16 @@ class WireguardWrapperService : GoBackend.VpnService() {
         // Cancel previous job if any
         updateJob?.cancel()
         var startedTunnel = false
+        var lastNotifiedStatus: ConnectionStatus? = null
+        var lastNotifiedStats: TunnelStatistics? = null
+        var lastNotifiedTitle: String? = null
+        var lastNotifiedAtMs = 0L
 
         updateJob = scope.launch {
             while (isActive) {
                 val status = backend.statusFlow.value
                 val stats = backend.latestStats
+            val notificationTitle = backend.tunnelName ?: "Mysterium VPN"
 
                 if (status == ConnectionStatus.connected) {
                     startedTunnel = true
@@ -54,11 +64,26 @@ class WireguardWrapperService : GoBackend.VpnService() {
                     stopSelf()
                     break
                 } else if (status != ConnectionStatus.disconnected) {
-                    notificationHelper.updateStatusNotification(
-                        status,
-                        stats,
-                        backend.tunnelName ?: "Mysterium VPN"
-                    )
+                    val statusOrTitleChanged =
+                        status != lastNotifiedStatus || notificationTitle != lastNotifiedTitle
+                    val statsChanged = stats != lastNotifiedStats
+                    val nowMs = SystemClock.elapsedRealtime()
+                    val intervalElapsed =
+                        nowMs - lastNotifiedAtMs >= NOTIFICATION_UPDATE_MIN_INTERVAL_MS
+                    val shouldUpdateNotification =
+                        statusOrTitleChanged || (statsChanged && intervalElapsed)
+
+                    if (shouldUpdateNotification) {
+                        notificationHelper.updateStatusNotification(
+                            status,
+                            stats,
+                            notificationTitle
+                        )
+                        lastNotifiedStatus = status
+                        lastNotifiedStats = stats
+                        lastNotifiedTitle = notificationTitle
+                        lastNotifiedAtMs = nowMs
+                    }
                 }
 
                 delay(1000)

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -55,7 +55,7 @@ class WireguardWrapperService : GoBackend.VpnService() {
         var lastNotifiedStatus: ConnectionStatus? = null
         var lastNotifiedStats: TunnelStatistics? = null
         var lastNotifiedTitle: String? = null
-        var lastNotifiedAtMs = 0L
+        var lastNotificationAttemptAtMs = 0L
 
         updateJob = scope.launch {
             while (isActive) {
@@ -78,11 +78,12 @@ class WireguardWrapperService : GoBackend.VpnService() {
                     val statsChanged = stats != lastNotifiedStats
                     val nowMs = SystemClock.elapsedRealtime()
                     val intervalElapsed =
-                        nowMs - lastNotifiedAtMs >= NOTIFICATION_UPDATE_MIN_INTERVAL_MS
+                        nowMs - lastNotificationAttemptAtMs >= NOTIFICATION_UPDATE_MIN_INTERVAL_MS
                     val shouldUpdateNotification =
                         statusOrTitleChanged || (statsChanged && intervalElapsed)
 
                     if (shouldUpdateNotification) {
+                        lastNotificationAttemptAtMs = nowMs
                         val notificationPosted = notificationHelper.updateStatusNotification(
                             status,
                             stats,
@@ -92,7 +93,6 @@ class WireguardWrapperService : GoBackend.VpnService() {
                             lastNotifiedStatus = status
                             lastNotifiedStats = stats
                             lastNotifiedTitle = notificationTitle
-                            lastNotifiedAtMs = nowMs
                         }
                     }
                 }

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -11,6 +11,7 @@ class WireguardWrapperService : GoBackend.VpnService() {
 
     companion object {
         private const val NOTIFICATION_UPDATE_MIN_INTERVAL_MS = 2_000L
+        private const val DEFAULT_NOTIFICATION_TITLE = "Mysterium VPN"
     }
 
     private val serviceTag = "WireguardWrapperService"
@@ -29,14 +30,16 @@ class WireguardWrapperService : GoBackend.VpnService() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val backend = WireguardBackend.getOrCreateInstance(this)
+        val initialNotificationTitle = backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
 
         // Show foreground notification immediately
-        startForeground(
+        notificationHelper.startForegroundSafely(
+            this,
             NotificationHelper.NOTIFICATION_ID,
             notificationHelper.buildTunnelNotification(
                 ConnectionStatus.connecting,
                 TunnelStatistics(0, 0, 0),
-                "VPN"
+                initialNotificationTitle
             )
         )
 
@@ -52,7 +55,7 @@ class WireguardWrapperService : GoBackend.VpnService() {
             while (isActive) {
                 val status = backend.statusFlow.value
                 val stats = backend.latestStats
-            val notificationTitle = backend.tunnelName ?: "Mysterium VPN"
+                val notificationTitle = backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
 
                 if (status == ConnectionStatus.connected) {
                     startedTunnel = true

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -83,15 +83,17 @@ class WireguardWrapperService : GoBackend.VpnService() {
                         statusOrTitleChanged || (statsChanged && intervalElapsed)
 
                     if (shouldUpdateNotification) {
-                        notificationHelper.updateStatusNotification(
+                        val notificationPosted = notificationHelper.updateStatusNotification(
                             status,
                             stats,
                             notificationTitle
                         )
-                        lastNotifiedStatus = status
-                        lastNotifiedStats = stats
-                        lastNotifiedTitle = notificationTitle
-                        lastNotifiedAtMs = nowMs
+                        if (notificationPosted) {
+                            lastNotifiedStatus = status
+                            lastNotifiedStats = stats
+                            lastNotifiedTitle = notificationTitle
+                            lastNotifiedAtMs = nowMs
+                        }
                     }
                 }
 

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -33,7 +33,7 @@ class WireguardWrapperService : GoBackend.VpnService() {
         val initialNotificationTitle = backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
 
         // Show foreground notification immediately
-        notificationHelper.startForegroundSafely(
+        val startedInForeground = notificationHelper.startForegroundSafely(
             this,
             NotificationHelper.NOTIFICATION_ID,
             notificationHelper.buildTunnelNotification(
@@ -42,6 +42,12 @@ class WireguardWrapperService : GoBackend.VpnService() {
                 initialNotificationTitle
             )
         )
+
+        if (!startedInForeground) {
+            Log.w(serviceTag, "Unable to start foreground notification, stopping service")
+            stopSelf()
+            return START_NOT_STICKY
+        }
 
         // Cancel previous job if any
         updateJob?.cancel()

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.13.0' apply false
+    id "com.android.application" version '8.13.2' apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/lib/src/wireguard_dart.dart
+++ b/lib/src/wireguard_dart.dart
@@ -1,6 +1,10 @@
 import 'models/models.dart';
 import 'wireguard_dart_platform_interface.dart';
 
+class WireguardErrorCodes {
+  static const String connectionFailed = 'ERR_WIREGUARD_CONNECTION';
+}
+
 class WireguardDart {
   Future<KeyPair> generateKeyPair() {
     return WireguardDartPlatform.instance.generateKeyPair();
@@ -10,10 +14,8 @@ class WireguardDart {
     return WireguardDartPlatform.instance.nativeInit();
   }
 
-  Future<void> setupTunnel(
-      {required String bundleId, required String tunnelName, String? win32ServiceName}) {
-    return WireguardDartPlatform.instance.setupTunnel(
-        bundleId: bundleId, tunnelName: tunnelName, win32ServiceName: win32ServiceName);
+  Future<void> setupTunnel({required String bundleId, required String tunnelName, String? win32ServiceName}) {
+    return WireguardDartPlatform.instance.setupTunnel(bundleId: bundleId, tunnelName: tunnelName, win32ServiceName: win32ServiceName);
   }
 
   Future<void> connect({required String cfg}) {


### PR DESCRIPTION
This pull request improves the notification handling for the Wireguard VPN Android service by making notification updates more efficient and robust. It introduces smarter notification update throttling, ensures proper permission checks, and simplifies the notification intent logic.

**Notification update efficiency:**
- Added logic in `WireguardWrapperService` to throttle notification updates, reducing redundant updates by only notifying when the status or title changes, or when statistics change after a minimum interval. This helps prevent excessive notification updates and conserves system resources. [[1]](diffhunk://#diff-ca92fc12b41c361a10effbbb384e23e8eb348cc79e8d021796e4eaa9285f7d8bR5-R15) [[2]](diffhunk://#diff-ca92fc12b41c361a10effbbb384e23e8eb348cc79e8d021796e4eaa9285f7d8bR46-R55) [[3]](diffhunk://#diff-ca92fc12b41c361a10effbbb384e23e8eb348cc79e8d021796e4eaa9285f7d8bR67-R86)

**Robustness and permission handling:**
- Updated `NotificationHelper` to check for the `POST_NOTIFICATIONS` permission on Android 13+ before attempting to show notifications, preventing potential crashes or security exceptions. Also added error logging for notification update failures. [[1]](diffhunk://#diff-6a54791cc7e274f8b6a54e1f25600856401f94dbe56efaf79a49336afb84d38fR3-R19) [[2]](diffhunk://#diff-6a54791cc7e274f8b6a54e1f25600856401f94dbe56efaf79a49336afb84d38fL53-R102)

**Simplification and code cleanup:**
- Simplified the logic for creating the notification's pending intent by using the package manager's launch intent directly and removed the now-unnecessary `getLaunchActivityClass` method. [[1]](diffhunk://#diff-6a54791cc7e274f8b6a54e1f25600856401f94dbe56efaf79a49336afb84d38fL53-R102) [[2]](diffhunk://#diff-6a54791cc7e274f8b6a54e1f25600856401f94dbe56efaf79a49336afb84d38fL90-L104)Reduce notification spam and harden notification handling. WireguardVpnService now throttles status/stat updates (2s min) and only updates when status/title change or stats changed after the interval. NotificationHelper: obtain launch intent via PackageManager, handle nullable PendingIntent, avoid reflection, check POST_NOTIFICATIONS on Android TIRAMISU, catch SecurityException when notifying, and log warnings. Misc: add related imports and a log tag.