### PR TITLE
Implement safe foreground service handling with ServiceCompat

### DIFF
--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
@@ -6,11 +6,13 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import java.util.Locale
 
 class NotificationHelper(private val context: Context) {
@@ -100,10 +102,18 @@ class NotificationHelper(private val context: Context) {
         notification: Notification,
     ): Boolean {
         return try {
-            service.startForeground(notificationId, notification)
+            // Match the foregroundServiceType declared in the manifest (systemExempted) on API 34+.
+            val serviceType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
+            } else {
+                0
+            }
+            ServiceCompat.startForeground(service, notificationId, notification, serviceType)
             true
-        } catch (e: SecurityException) {
-            Log.w(logTag, "Unable to start foreground notification due to security restriction", e)
+        } catch (e: Exception) {
+            // Includes SecurityException and ForegroundServiceStartNotAllowedException. Never let
+            // this escape onCreate/onStartCommand as an uncaught crash.
+            Log.w(logTag, "Unable to start foreground service", e)
             false
         }
     }

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/NotificationHelper.kt
@@ -5,8 +5,8 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
+import android.content.ComponentName
 import android.content.pm.PackageManager
-import android.content.pm.ServiceInfo
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -102,19 +102,34 @@ class NotificationHelper(private val context: Context) {
         notification: Notification,
     ): Boolean {
         return try {
-            // Match the foregroundServiceType declared in the manifest (systemExempted) on API 34+.
-            val serviceType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
-            } else {
-                0
-            }
-            ServiceCompat.startForeground(service, notificationId, notification, serviceType)
+            ServiceCompat.startForeground(
+                service,
+                notificationId,
+                notification,
+                declaredForegroundServiceType(service)
+            )
             true
         } catch (e: Exception) {
             // Includes SecurityException and ForegroundServiceStartNotAllowedException. Never let
             // this escape onCreate/onStartCommand as an uncaught crash.
             Log.w(logTag, "Unable to start foreground service", e)
             false
+        }
+    }
+
+    // Read the foregroundServiceType actually declared in the merged manifest for this service so
+    // the bitmask passed to startForeground() always matches the manifest across API levels.
+    private fun declaredForegroundServiceType(service: Service): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return 0
+        }
+        return try {
+            service.packageManager
+                .getServiceInfo(ComponentName(service, service.javaClass), 0)
+                .foregroundServiceType
+        } catch (e: PackageManager.NameNotFoundException) {
+            Log.w(logTag, "Unable to read declared foregroundServiceType, defaulting to 0", e)
+            0
         }
     }
 

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -24,30 +24,41 @@ class WireguardWrapperService : GoBackend.VpnService() {
         notificationHelper = NotificationHelper(this)
         NotificationHelper.initNotificationChannel(this)
         val backend = WireguardBackend.getOrCreateInstance(this)
+
+        // Satisfy the startForegroundService() contract as early as possible. Android arms a
+        // ~10s deadline at startForegroundService() and crashes the process with
+        // ForegroundServiceDidNotStartInTimeException if startForeground() is not called in time.
+        // Doing it here (instead of only in onStartCommand) guarantees we beat the deadline even
+        // when the main thread is busy or onStartCommand is delayed.
+        notificationHelper.startForegroundSafely(
+            this,
+            NotificationHelper.NOTIFICATION_ID,
+            notificationHelper.buildTunnelNotification(
+                ConnectionStatus.connecting,
+                TunnelStatistics(0, 0, 0),
+                backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
+            )
+        )
+
         backend.serviceCreated(this)
         Log.d(serviceTag, "Service created")
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val backend = WireguardBackend.getOrCreateInstance(this)
-        val initialNotificationTitle = backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
 
-        // Show foreground notification immediately
-        val startedInForeground = notificationHelper.startForegroundSafely(
+        // The foreground notification is already posted in onCreate to beat the
+        // startForegroundService() deadline. Re-assert it here (idempotent) so a system restart
+        // that reuses an existing instance keeps the service in the foreground.
+        notificationHelper.startForegroundSafely(
             this,
             NotificationHelper.NOTIFICATION_ID,
             notificationHelper.buildTunnelNotification(
                 ConnectionStatus.connecting,
                 TunnelStatistics(0, 0, 0),
-                initialNotificationTitle
+                backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
             )
         )
-
-        if (!startedInForeground) {
-            Log.w(serviceTag, "Unable to start foreground notification, stopping service")
-            stopSelf()
-            return START_NOT_STICKY
-        }
 
         // Cancel previous job if any
         updateJob?.cancel()

--- a/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
+++ b/android/src/main/kotlin/network/mysterium/wireguard_dart/WireguardVpnService.kt
@@ -18,6 +18,7 @@ class WireguardWrapperService : GoBackend.VpnService() {
     private val scope = CoroutineScope(Job() + Dispatchers.Main)
     private lateinit var notificationHelper: NotificationHelper
     private var updateJob: Job? = null
+    private var startedInForeground = false
 
     override fun onCreate() {
         super.onCreate()
@@ -30,7 +31,7 @@ class WireguardWrapperService : GoBackend.VpnService() {
         // ForegroundServiceDidNotStartInTimeException if startForeground() is not called in time.
         // Doing it here (instead of only in onStartCommand) guarantees we beat the deadline even
         // when the main thread is busy or onStartCommand is delayed.
-        notificationHelper.startForegroundSafely(
+        startedInForeground = notificationHelper.startForegroundSafely(
             this,
             NotificationHelper.NOTIFICATION_ID,
             notificationHelper.buildTunnelNotification(
@@ -39,6 +40,15 @@ class WireguardWrapperService : GoBackend.VpnService() {
                 backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
             )
         )
+
+        if (!startedInForeground) {
+            // The startForegroundService() contract can no longer be met. Stop now: a destroying
+            // service makes the system's foreground-timeout handler bail out, so we avoid the
+            // ForegroundServiceDidNotStartInTimeException instead of lingering with an unmet contract.
+            Log.w(serviceTag, "Unable to enter foreground in onCreate, stopping service")
+            stopSelf()
+            return
+        }
 
         backend.serviceCreated(this)
         Log.d(serviceTag, "Service created")
@@ -47,18 +57,31 @@ class WireguardWrapperService : GoBackend.VpnService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val backend = WireguardBackend.getOrCreateInstance(this)
 
-        // The foreground notification is already posted in onCreate to beat the
-        // startForegroundService() deadline. Re-assert it here (idempotent) so a system restart
-        // that reuses an existing instance keeps the service in the foreground.
-        notificationHelper.startForegroundSafely(
-            this,
-            NotificationHelper.NOTIFICATION_ID,
-            notificationHelper.buildTunnelNotification(
-                ConnectionStatus.connecting,
-                TunnelStatistics(0, 0, 0),
-                backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
+        // The foreground notification is normally posted in onCreate to beat the
+        // startForegroundService() deadline. Re-assert it here (idempotent) so a re-delivered
+        // start that reuses an existing instance keeps the service in the foreground.
+        if (notificationHelper.startForegroundSafely(
+                this,
+                NotificationHelper.NOTIFICATION_ID,
+                notificationHelper.buildTunnelNotification(
+                    ConnectionStatus.connecting,
+                    TunnelStatistics(0, 0, 0),
+                    backend.tunnelName ?: DEFAULT_NOTIFICATION_TITLE
+                )
             )
-        )
+        ) {
+            startedInForeground = true
+        }
+
+        if (!startedInForeground) {
+            // Foreground was never successfully established (onCreate's attempt failed and this one
+            // did too), so the startForegroundService() contract is unmet. Stop rather than risk
+            // ForegroundServiceDidNotStartInTimeException. A failed re-assert while already in the
+            // foreground is harmless and intentionally does not stop a working tunnel.
+            Log.w(serviceTag, "Unable to enter foreground in onStartCommand, stopping service")
+            stopSelf()
+            return START_NOT_STICKY
+        }
 
         // Cancel previous job if any
         updateJob?.cancel()


### PR DESCRIPTION
This pull request improves the reliability and compatibility of foreground service notifications for the Wireguard VPN Android service, especially on newer Android versions. The main focus is on ensuring the service meets Android's strict requirements for foreground services, preventing crashes related to delayed foreground notification posting, and updating the notification logic to use more robust APIs.

**Foreground service notification improvements:**

* The foreground notification is now posted as early as possible in `onCreate` of `WireguardWrapperService`, ensuring compliance with Android's 10-second deadline for foreground services and preventing `ForegroundServiceDidNotStartInTimeException` crashes. The notification is also re-asserted in `onStartCommand` to handle system restarts gracefully.
* The `startForegroundSafely` method in `NotificationHelper` now uses `ServiceCompat.startForeground` instead of the deprecated `startForeground`, with logic to specify the correct `foregroundServiceType` on Android 14+ (API 34, "Upside Down Cake"). This ensures compatibility with newer Android requirements.
* Improved error handling in `startForegroundSafely` to catch all exceptions (not just `SecurityException`) and log them, preventing uncaught crashes during service startup.

**Dependency and import updates:**

* Added imports for `android.content.pm.ServiceInfo` and `androidx.core.app.ServiceCompat` to support the updated notification logic and foreground service type handling.Switch to ServiceCompat.startForeground (passing ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED on API 34+) and broaden error handling in NotificationHelper so failures (e.g. SecurityException/ForegroundServiceStartNotAllowedException) are logged and do not crash the process. In WireguardVpnService, post the foreground notification in onCreate to satisfy the startForegroundService() deadline and re-assert it in onStartCommand (idempotent) so the service remains foreground after restarts; remove the stopSelf() path on start failures. These changes avoid startForeground timing crashes and match the manifest's foregroundServiceType on newer Android.